### PR TITLE
Add video splitting with 4m30s rejection ceiling

### DIFF
--- a/adapters/whatsapp/processor.py
+++ b/adapters/whatsapp/processor.py
@@ -7,10 +7,14 @@ to wire it to the ``download_complete`` signal:
     from adapters.whatsapp import processor
     processor.connect()
 
-The processing order is:
-1. Trim to max duration (fast stream copy, reduces data for subsequent steps).
-2. Ensure H.264/AAC codec (re-encodes if needed).
-3. Enforce max file size (re-encodes at lower bitrate if the file is too large).
+Processing steps, in order:
+
+1. Reject if total duration exceeds the maximum splittable length (4m30s).
+   A message is printed and preparation is skipped.
+2. Split into sequential parts of at most 90 seconds each.
+   The original file is kept; parts are written alongside it as
+   ``<stem>_part1.mp4``, ``<stem>_part2.mp4``, etc.
+3. For each part: ensure H.264/AAC codec, then enforce the 16 MB size limit.
 
 Constraint values are read from the ``whatsapp_status`` destination adapter
 so they stay in sync with the registry.
@@ -20,25 +24,47 @@ from functools import partial
 from pathlib import Path
 
 from adapters.destinations.registry import get as get_destination
-from adapters.whatsapp import codec, resize, trim
+from adapters.whatsapp import codec, resize, split
+from adapters.whatsapp._ffmpeg import probe_duration
 from domain import signals
 from domain.pipeline import ProcessorFn, build_pipeline
 
 _c = get_destination("whatsapp_status").constraints
 
-_steps: list[ProcessorFn] = []
-if _c.max_duration_seconds is not None:
-    _steps.append(partial(trim.trim_to_duration, max_seconds=_c.max_duration_seconds))
-_steps.append(codec.ensure_h264_aac)
-if _c.max_file_mb is not None:
-    _steps.append(partial(resize.enforce_max_mb, max_mb=_c.max_file_mb))
+# Videos longer than this are rejected: 3 x max_duration_seconds = 4m30s.
+MAX_TOTAL_SECONDS: int = 3 * (_c.max_duration_seconds or 90)
 
-_pipeline = build_pipeline(_steps)
+# Post-split pipeline: codec + resize (no trim — each part is already ≤ 90s).
+_post_split_steps: list[ProcessorFn] = [codec.ensure_h264_aac]
+if _c.max_file_mb is not None:
+    _post_split_steps.append(partial(resize.enforce_max_mb, max_mb=_c.max_file_mb))
+
+_post_split_pipeline = build_pipeline(_post_split_steps)
+
+
+def _warn_too_long(duration: float) -> None:
+    mins = int(duration) // 60
+    secs = int(duration) % 60
+    max_mins = MAX_TOTAL_SECONDS // 60
+    max_secs = MAX_TOTAL_SECONDS % 60
+    print(
+        f"\nVideo too long for WhatsApp ({mins}m{secs:02d}s). "
+        f"Maximum is {max_mins}m{max_secs:02d}s. "
+        "Skipping WhatsApp preparation."
+    )
 
 
 def _prepare_for_whatsapp(file_path: Path, **_: object) -> None:
     try:
-        _pipeline(file_path)
+        duration = probe_duration(file_path)
+        if duration is not None and duration > MAX_TOTAL_SECONDS:
+            _warn_too_long(duration)
+            return
+
+        part_duration = _c.max_duration_seconds or 90
+        parts = split.split_by_duration(file_path, max_seconds=part_duration)
+        for part in parts:
+            _post_split_pipeline(part)
     except Exception:
         # Processing failure must not affect the download result.
         # A future logging adapter will record errors here.

--- a/adapters/whatsapp/split.py
+++ b/adapters/whatsapp/split.py
@@ -1,0 +1,55 @@
+"""
+Split step — divides a video into sequential parts of a fixed maximum duration.
+
+Each part uses stream copy (``-c copy``) for speed. Split points are
+keyframe-aligned by ffmpeg, so actual part durations may be slightly shorter
+than ``max_seconds``. The original file is never modified or deleted.
+
+Output naming: ``<stem>_part1.mp4``, ``<stem>_part2.mp4``, etc., next to
+the original file.
+"""
+
+import math
+import subprocess
+from pathlib import Path
+
+from adapters.whatsapp._ffmpeg import probe_duration
+
+
+def split_by_duration(path: Path, max_seconds: int) -> list[Path]:
+    """Split the video into parts of at most ``max_seconds`` each.
+
+    Returns ``[path]`` unchanged if the video is already within the limit
+    or if the duration cannot be determined. Otherwise returns a list of
+    part paths. The number of parts is ``ceil(duration / max_seconds)``.
+    """
+    duration = probe_duration(path)
+    if duration is None or duration <= max_seconds:
+        return [path]
+
+    n_parts = math.ceil(duration / max_seconds)
+    parts: list[Path] = []
+
+    for i in range(n_parts):
+        start = i * max_seconds
+        part_path = path.with_stem(f"{path.stem}_part{i + 1}")
+        subprocess.run(
+            [
+                "ffmpeg",
+                "-y",
+                "-ss",
+                str(start),
+                "-i",
+                str(path),
+                "-t",
+                str(max_seconds),
+                "-c",
+                "copy",
+                str(part_path),
+            ],
+            check=True,
+            capture_output=True,
+        )
+        parts.append(part_path)
+
+    return parts

--- a/tests/adapters/test_whatsapp_steps.py
+++ b/tests/adapters/test_whatsapp_steps.py
@@ -1,13 +1,16 @@
 """
-WhatsApp adapter tests — trim, codec, resize, and processor.
+WhatsApp adapter tests — trim, codec, resize, split, and processor.
 
 Each test that modifies a file uses a per-test copy from conftest.py so
 session-scoped fixtures remain intact.
 """
 
 from pathlib import Path
+from unittest.mock import patch
 
-from adapters.whatsapp import codec, resize, trim
+import pytest
+
+from adapters.whatsapp import codec, resize, split, trim
 from adapters.whatsapp._ffmpeg import probe_audio_codec, probe_duration, probe_video_codec
 
 
@@ -86,6 +89,48 @@ class TestFfmpegProbes:
         assert probe_video_codec(tiny_mpeg4_video) == "mpeg4"
 
 
+class TestSplitByDuration:
+    def test_returns_single_path_when_within_limit(self, h264_video: Path) -> None:
+        result = split.split_by_duration(h264_video, max_seconds=10)
+        assert result == [h264_video]
+
+    def test_original_is_unchanged_when_within_limit(self, h264_video: Path) -> None:
+        size_before = h264_video.stat().st_size
+        split.split_by_duration(h264_video, max_seconds=10)
+        assert h264_video.stat().st_size == size_before
+
+    def test_splits_into_correct_number_of_parts(self, h264_video: Path) -> None:
+        # 3s video split at 1s → 3 parts
+        parts = split.split_by_duration(h264_video, max_seconds=1)
+        assert len(parts) == 3
+
+    def test_part_paths_follow_naming_convention(self, h264_video: Path) -> None:
+        parts = split.split_by_duration(h264_video, max_seconds=1)
+        stems = [p.stem for p in parts]
+        assert stems == ["h264_part1", "h264_part2", "h264_part3"]
+
+    def test_each_part_is_within_duration_limit(self, h264_video: Path) -> None:
+        parts = split.split_by_duration(h264_video, max_seconds=1)
+        for part in parts:
+            duration = probe_duration(part)
+            assert duration is not None
+            assert duration <= 1.5  # 0.5s tolerance for keyframe alignment
+
+    def test_original_file_is_preserved_after_split(self, h264_video: Path) -> None:
+        split.split_by_duration(h264_video, max_seconds=1)
+        assert h264_video.exists()
+
+    def test_part_files_exist_on_disk(self, h264_video: Path) -> None:
+        parts = split.split_by_duration(h264_video, max_seconds=1)
+        for part in parts:
+            assert part.exists()
+
+    def test_split_two_parts(self, h264_video: Path) -> None:
+        # 3s video split at 2s → 2 parts
+        parts = split.split_by_duration(h264_video, max_seconds=2)
+        assert len(parts) == 2
+
+
 class TestWhatsAppProcessor:
     def test_connect_registers_receiver_on_download_complete(self) -> None:
         from adapters.whatsapp import processor
@@ -110,3 +155,35 @@ class TestWhatsAppProcessor:
         from adapters.whatsapp.processor import _prepare_for_whatsapp
 
         _prepare_for_whatsapp(file_path=tmp_path / "ghost.mp4")  # no error
+
+    def test_prepare_for_whatsapp_warns_when_too_long(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        from adapters.whatsapp import processor
+
+        video = tmp_path / "long.mp4"
+        video.touch()
+
+        with patch(
+            "adapters.whatsapp.processor.probe_duration",
+            return_value=float(processor.MAX_TOTAL_SECONDS + 1),
+        ):
+            processor._prepare_for_whatsapp(file_path=video)
+
+        out = capsys.readouterr().out
+        assert "too long" in out.lower()
+        assert "4m30s" in out
+
+    def test_prepare_for_whatsapp_does_not_warn_at_exact_limit(
+        self, h264_video: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        from adapters.whatsapp import processor
+
+        with patch(
+            "adapters.whatsapp.processor.probe_duration",
+            return_value=float(processor.MAX_TOTAL_SECONDS),
+        ):
+            processor._prepare_for_whatsapp(file_path=h264_video)
+
+        out = capsys.readouterr().out
+        assert "too long" not in out.lower()


### PR DESCRIPTION
## Summary

- Adds `adapters/whatsapp/split.py` — splits a video into sequential parts using ffmpeg stream copy
- Redesigns `processor.py`: trim step removed; split replaces it; post-split pipeline applies codec + resize to each part
- Videos > 270s (4m30s) are rejected with a human-readable message; videos ≤ 90s are passed through unchanged
- `MAX_TOTAL_SECONDS` is derived from the registry so it stays in sync with `WhatsAppStatus.constraints`

## Test plan

- [ ] `split_by_duration` returns `[path]` unchanged when video is within limit
- [ ] `split_by_duration` produces the correct number of parts (`ceil(duration / max_seconds)`)
- [ ] Part paths follow `<stem>_part{n}.mp4` naming convention
- [ ] Each part duration is within the limit (±0.5s keyframe tolerance)
- [ ] Original file is preserved after split
- [ ] `_prepare_for_whatsapp` prints a "too long" warning when duration > 270s
- [ ] No warning is printed when duration == 270s (boundary: included)

🤖 Generated with [Claude Code](https://claude.com/claude-code)